### PR TITLE
Add uuid check on filter

### DIFF
--- a/spec/Database.spec.ts
+++ b/spec/Database.spec.ts
@@ -25,7 +25,7 @@ describe('Database', () => {
 
   describe('#resources', () => {
     it('returns all entities', async () => {
-      expect(new Database(prisma).resources()).toHaveLength(3);
+      expect(new Database(prisma).resources()).toHaveLength(4);
     });
   });
 });

--- a/spec/Resource.spec.ts
+++ b/spec/Resource.spec.ts
@@ -106,6 +106,44 @@ describe('Resource', () => {
     });
   });
 
+  describe('#find', () => {
+    let record: BaseRecord[];
+
+    it('finds by record name', async () => {
+      const params = await resource.create(data);
+      await resource.create({
+        name: 'Another one',
+        email: 'another@email.com',
+      });
+
+      const filter = new Filter(undefined, resource);
+      filter.filters = {
+        name: { path: 'name', value: params.name, property: resource.property('name') as BaseProperty },
+      }
+      record = await resource.find(filter);
+
+      expect(record[0] && record[0].get('name')).toEqual(data.name);
+      expect(record[0] && record[0].get('email')).toEqual(data.email);
+      expect(record.length).toEqual(1);
+    });
+
+    it('finds by record uuid column', async () => {
+      const uuidResource = new Resource({ model: dmmf.modelMap.UuidExample, client: prisma });
+      const params = await uuidResource.create({ label: 'test' });
+      await uuidResource.create({ label: 'another test' });
+
+      const filter = new Filter(undefined, uuidResource);
+      filter.filters = {
+        id: { path: 'id', value: params.id, property: uuidResource.property('id') as BaseProperty },
+      }
+      record = await uuidResource.find(filter);
+
+      expect(record[0] && record[0].get('id')).toEqual(params.id);
+      expect(record[0] && record[0].get('label')).toEqual('test');
+      expect(record.length).toEqual(1);
+    });
+  });
+
   describe('references', () => {
     let profile;
     let user;

--- a/spec/prisma/migrations/20211122063611_uuid_ossp_extension/migration.sql
+++ b/spec/prisma/migrations/20211122063611_uuid_ossp_extension/migration.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/spec/prisma/schema.prisma
+++ b/spec/prisma/schema.prisma
@@ -39,3 +39,8 @@ model User {
   posts   Post[]
   profile Profile?
 }
+
+model UuidExample {
+  id      String      @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  label   String
+}

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -32,6 +32,7 @@ export const convertParam = (
 export const convertFilter = (modelFields: DMMF.Model['fields'], filterObject?: Filter): Record<string, any> => {
   if (!filterObject) return {};
 
+  const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[5|4|3|2|1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
   const { filters = {} } = filterObject;
   return Object.entries(filters).reduce((where, [name, filter]) => {
     if (['boolean', 'number', 'float', 'object', 'array'].includes(filter.property.type())) {
@@ -45,6 +46,8 @@ export const convertFilter = (modelFields: DMMF.Model['fields'], filterObject?: 
         where[name] = { lte: new Date(filter.value.to) };
       }
     } else if ((filter.property as Property).isEnum()) {
+      where[name] = { equals: filter.value };
+    } else if (filter.property.type() === 'string' && uuidRegex.test(filter.value.toString())) {
       where[name] = { equals: filter.value };
     } else if (filter.property.type() === 'reference' && (filter.property as Property).foreignColumnName()) {
       where[(filter.property as Property).foreignColumnName() as string] = convertParam(


### PR DESCRIPTION
If the database is Postgres and the column type is UUID, the "String contains" from Prisma cause an exception.

To check the error just comment on my changes on file `src/utils/converters.ts`.

I did a quick research about this problem that seems to be related to Postgres and UUID, probably the best solution is Prisma to add a UUID type them here we can deal properly with this column type, but until Prisma deals with UUID like String, I was not able to detect if the column type is UUID.
