### PR TITLE
chore: upgrade to prisma 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ AdminJS.registerAdapter({ Database, Resource })
 const run = async () => {
   const app = express()
 
-  // `_dmmf` contains necessary Model metadata. `PrismaClient` type doesn't have it included
-  const dmmf = ((prisma as any)._dmmf as DMMFClass)
+  // `_baseDmmf` contains necessary Model metadata. `PrismaClient` type doesn't have it included
+  const dmmf = ((prisma as any)._baseDmmf as DMMFClass)
 
   const admin = new AdminJS({
     resources: [{

--- a/example-app/src/index.ts
+++ b/example-app/src/index.ts
@@ -15,7 +15,7 @@ AdminJS.registerAdapter({ Database, Resource });
 const run = async () => {
   const app = express();
 
-  const dmmf = ((prisma as any)._dmmf as DMMFClass);
+  const dmmf = ((prisma as any)._baseDmmf as DMMFClass);
 
   const admin = new AdminJS({
     resources: [{

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@prisma/client": "^3.2.1",
+    "@prisma/client": "^4.0.0",
     "@semantic-release/git": "^9.0.0",
     "@types/jest": "^27.0.2",
     "@types/node": "12.0.10",
@@ -61,7 +61,7 @@
     "husky": "^4.2.5",
     "jest": "^27.2.5",
     "pg": "^7.12.1",
-    "prisma": "^3.2.1",
+    "prisma": "^4.0.0",
     "semantic-release": "^17.0.7",
     "semantic-release-slack-bot": "^1.6.2",
     "ts-jest": "^27.0.5",

--- a/spec/Property.spec.ts
+++ b/spec/Property.spec.ts
@@ -16,7 +16,7 @@ describe('Property', () => {
 
   beforeAll(async () => {
     prisma = new PrismaClient();
-    const dmmf = ((prisma as any)._dmmf as DMMFClass);
+    const dmmf = ((prisma as any)._baseDmmf as DMMFClass);
     resource = new Resource({ model: dmmf.modelMap.Post, client: prisma });
     properties = resource.properties();
   });

--- a/spec/Resource.spec.ts
+++ b/spec/Resource.spec.ts
@@ -16,7 +16,7 @@ describe('Resource', () => {
 
   beforeAll(async () => {
     prisma = new PrismaClient();
-    dmmf = ((prisma as any)._dmmf as DMMFClass);
+    dmmf = ((prisma as any)._baseDmmf as DMMFClass);
   });
 
   beforeEach(async () => {

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -14,7 +14,7 @@ export class Database extends BaseDatabase {
   }
 
   public resources(): Array<Resource> {
-    const dmmf = (this.client as any)._dmmf as DMMFClass;
+    const dmmf = (this.client as any)._baseDmmf as DMMFClass;
     const { modelMap } = dmmf;
 
     if (!modelMap) return [];
@@ -26,7 +26,7 @@ export class Database extends BaseDatabase {
   }
 
   public static isAdapterFor(prisma: PrismaClient): boolean {
-    const dmmf = ((prisma as any)._dmmf as DMMFClass);
+    const dmmf = ((prisma as any)._baseDmmf as DMMFClass);
 
     return !!dmmf?.modelMap && !!Object.values(dmmf?.modelMap ?? {}).length;
   }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -68,7 +68,7 @@ export class Property extends BaseProperty {
 
     if (!enumSchema) return null;
 
-    return enumSchema.values.map((value) => String(value)) ?? [];
+    return enumSchema.values.map((value) => String(value.name)) ?? [];
   }
 
   public position(): number {

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -27,7 +27,7 @@ export class Resource extends BaseResource {
     const { model, client } = args;
     this.model = model;
     this.client = client;
-    this.enums = (this.client as any)._dmmf.enumMap;
+    this.enums = (this.client as any)._baseDmmf.datamodelEnumMap;
     this.manager = this.client[lowerCase(model.name)];
     this.propertiesObject = this.prepareProperties();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@
  * const run = async () => {
  *   const app = express()
  *
- *   // `_dmmf` contains necessary Model metadata. `PrismaClient` type doesn't have it included
- *   const dmmf = ((prisma as any)._dmmf as DMMFClass)
+ *   // `_baseDmmf` contains necessary Model metadata. `PrismaClient` type doesn't have it included
+ *   const dmmf = ((prisma as any)._baseDmmf as DMMFClass)
  *
  *   const admin = new AdminJS({
  *     resources: [{

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,4 @@ export type ModelManager = {
   [action in DMMF.ModelAction]: (...args: any[]) => Promise<any>;
 };
 
-export type Enums = { [key: string]: DMMF.SchemaEnum };
+export type Enums = { [key: string]: DMMF.DatamodelEnum };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,22 +2118,22 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
-"@prisma/client@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.2.1.tgz#b0c60b4c42ec5b701a271380780c70de55bc3311"
-  integrity sha512-nakt9YoDFD4cgTkRTSVbzG40AKmmbVEtXE3csVqBdDXsm0/L4PQdtbtzILNzq28xv8HH8oHgFKWnsItM23mSDw==
+"@prisma/client@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.0.0.tgz#ed2f46930a1da0d8ae88d7965485973576b04270"
+  integrity sha512-g1h2OGoRo7anBVQ9Cw3gsbjwPtvf7i0pkGxKeZICtwkvE5CZXW+xZF4FZdmrViYkKaAShbISL0teNpu9ecpf4g==
   dependencies:
-    "@prisma/engines-version" "3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
+    "@prisma/engines-version" "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
 
-"@prisma/engines-version@3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version "3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c.tgz#63032b40ee09f56ec423eb47617c26de125ffb1e"
-  integrity sha512-O4dHSbqfX7yAjFMawIEzv6wefv3LRMDK4J20Y70NvE3otbE3CnChlmghkCvMsQ1CGF1QuGlrqfw20aI2JfZcaw==
+"@prisma/engines-version@3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz#4b5efe5eee2feef12910e4627a572cd96ed83236"
+  integrity sha512-PiZhdD624SrYEjyLboI0X7OugNbxUzDJx9v/6ldTKuqNDVUCmRH/Z00XwDi/dgM4FlqOSO+YiUsSiSKjxxG8cw==
 
-"@prisma/engines@3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version "3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c.tgz#d2a41a76a89548ea411043c3198eee4a75475dbb"
-  integrity sha512-wnHODKLQGKkE2ZCHxHQEf/4Anq/EP0ZCvX++D5w34033mwZ94iZiOsEKZZ31fgki7MTh28F1VNF5ZSFdnRjgvQ==
+"@prisma/engines@3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz#82f0018153cffa05d61422f9c0c7b0479b180f75"
+  integrity sha512-u/rG4lDHALolWBLr3yebZ+N2qImp3SDMcu7bHNJuRDaYvYEXy/MqfNRNEgd9GoPsXL3gofYf0VzJf2AmCG3YVw==
 
 "@rollup/plugin-babel@^5.2.1":
   version "5.3.0"
@@ -8067,12 +8067,12 @@ pretty-format@^27.0.0, pretty-format@^27.2.5:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prisma@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.2.1.tgz#696871f6d0e374df2de96297df4c04756ee6e3b5"
-  integrity sha512-nXhldcFYemNSMqdTAEziggVWBNbCHTrr0amkCJruP3G2AFpzxrKtksPRLYNetxdKMJAt7aRRumusbtmTTDgyzw==
+prisma@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.0.0.tgz#4ddb8fcd4f64d33aff8c198a6986dcce66dc8152"
+  integrity sha512-Dtsar03XpCBkcEb2ooGWO/WcgblDTLzGhPcustbehwlFXuTMliMDRzXsfygsgYwQoZnAUKRd1rhpvBNEUziOVw==
   dependencies:
-    "@prisma/engines" "3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
+    "@prisma/engines" "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
 
 proc-log@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is a breaking change to use Prisma 4's _baseDmmf instead of the previous _dmmf.

Thanks to @NotAmaan and @younes0 for providing the original patches in #13.

Closes https://github.com/SoftwareBrothers/adminjs-prisma/issues/13