### PR TITLE
fix: parse enum property for given clientModule

### DIFF
--- a/src/Database.ts
+++ b/src/Database.ts
@@ -24,7 +24,7 @@ export class Database extends BaseDatabase {
     if (!dmmf?.models) return [];
 
     return dmmf.models.map((model: DMMF.Model) => {
-      const resource = new Resource({ model, client: this.client });
+      const resource = new Resource({ model, client: this.client, clientModule: this.clientModule });
       return resource;
     });
   }


### PR DESCRIPTION
Currently, the latest version of adminjs-prisma using extra clientModule doesn't parse enums properly.  
I think `Resource` should get clientModule as args from `Database` just like I committed.  