### PR TITLE
fix: id filtering crash by adding MongoDB ObjectIDs support in convertFilter function

### DIFF
--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -34,6 +34,8 @@ export const convertFilter = (modelFields: DMMF.Model['fields'], filterObject?: 
   if (!filterObject) return {};
 
   const uuidRegex = /^[0-9A-F]{8}-[0-9A-F]{4}-[5|4|3|2|1][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
+  const objectIdRegex = /^[0-9a-fA-F]{24}$/;
+
   const { filters = {} } = filterObject;
   return Object.entries(filters).reduce((where, [name, filter]) => {
     if (['boolean', 'number', 'float', 'object', 'array'].includes(filter.property.type())) {
@@ -48,7 +50,9 @@ export const convertFilter = (modelFields: DMMF.Model['fields'], filterObject?: 
       }
     } else if ((filter.property as Property).isEnum()) {
       where[name] = { equals: filter.value };
-    } else if (filter.property.type() === 'string' && uuidRegex.test(filter.value.toString())) {
+    } else if (
+      filter.property.type() === 'string'
+      && (uuidRegex.test(filter.value.toString()) || objectIdRegex.test(filter.value.toString()))) {
       where[name] = { equals: filter.value };
     } else if (filter.property.type() === 'reference' && (filter.property as Property).foreignColumnName()) {
       where[(filter.property as Property).foreignColumnName() as string] = convertParam(


### PR DESCRIPTION
This pull request resolves a runtime crash issue in the `convertFilter` function within the adminJS-prisma adapter when filtering by MongoDB ObjectIDs. The existing implementation supported UUIDs for ID fields, but did not handle MongoDB ObjectIDs, leading to errors (panic in Prisma Query Engine). The changes introduced include:

- Extending the existing ID filtering logic to recognize and correctly process MongoDB ObjectIDs using a direct match approach (`equals` operator), ensuring compatibility and preventing crashes.
