### PR TITLE
refactor: change private properties to protected for extensibility

### DIFF
--- a/src/Database.ts
+++ b/src/Database.ts
@@ -6,9 +6,9 @@ import { BaseDatabase } from 'adminjs';
 import { Resource } from './Resource.js';
 
 export class Database extends BaseDatabase {
-  private client: PrismaClient;
+  protected client: PrismaClient;
 
-  private clientModule?: any;
+  protected clientModule?: any;
 
   public constructor(args: { client: PrismaClient, clientModule?: any }) {
     super(args);

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -7,9 +7,9 @@ import { DATA_TYPES } from './utils/data-types.js';
 export class Property extends BaseProperty {
   public column: DMMF.Field;
 
-  private enums: Enums;
+  protected enums: Enums;
 
-  private columnPosition: number;
+  protected columnPosition: number;
 
   // eslint-disable-next-line default-param-last
   constructor(column: DMMF.Field, columnPosition = 0, enums: Enums) {

--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -12,17 +12,17 @@ import { convertFilter, convertParam } from './utils/converters.js';
 import { getEnums } from './utils/get-enums.js';
 
 export class Resource extends BaseResource {
-  private client: PrismaClient;
+  protected client: PrismaClient;
 
-  private model: DMMF.Model;
+  protected model: DMMF.Model;
 
-  private enums: Enums;
+  protected enums: Enums;
 
-  private manager: ModelManager;
+  protected manager: ModelManager;
 
-  private propertiesObject: Record<string, Property>;
+  protected propertiesObject: Record<string, Property>;
 
-  private idProperty: Property;
+  protected idProperty: Property;
 
   constructor(args: {
     model: DMMF.Model;
@@ -96,7 +96,7 @@ export class Resource extends BaseResource {
     );
   }
 
-  private buildSortBy(sort: { sortBy?: string; direction?: 'asc' | 'desc' } = {}) {
+  protected buildSortBy(sort: { sortBy?: string; direction?: 'asc' | 'desc' } = {}) {
     let { sortBy: path } = sort;
     const { direction = 'desc' } = sort;
 
@@ -208,7 +208,7 @@ export class Resource extends BaseResource {
     );
   }
 
-  private prepareProperties(): { [propertyPath: string]: Property } {
+  protected prepareProperties(): { [propertyPath: string]: Property } {
     const { fields = [] } = this.model;
 
     const properties = fields.reduce((memo, field) => {
@@ -232,7 +232,7 @@ export class Resource extends BaseResource {
     return properties;
   }
 
-  private prepareParams(params: Record<string, any>): Record<string, any> {
+  protected prepareParams(params: Record<string, any>): Record<string, any> {
     const preparedParams: Record<string, any> = {};
 
     for (const property of this.properties()) {
@@ -268,7 +268,7 @@ export class Resource extends BaseResource {
     return preparedParams;
   }
 
-  private prepareReturnValues(
+  protected prepareReturnValues(
     params: Record<string, any>,
   ): Record<string, any> {
     const preparedValues: Record<string, any> = {};


### PR DESCRIPTION
Thanks for building AdminJS!

I ran into a little snag when trying to extend some of the Prisma resource functionalities, specifically with the `buildSortBy`, `model`... properties being private:

```
class PermissionCheckedResource extends Prisma.Resource {
  findOne(...) {
    this.buildSortBy
     ^ this method is private thus cannot update behavior easily
  }
}
```

Having this method as private means a lot of repeating code if we try to customize behavior. It would be awesome if it could be switched to protected to make subclassing a breeze and keep our codebase clean.

Thought this might make AdminJS more flexible for others too who might be looking to extend functionality in similar ways.

Thanks for considering this tweak!